### PR TITLE
Update yolo.py

### DIFF
--- a/xyolo/yolo3/yolo.py
+++ b/xyolo/yolo3/yolo.py
@@ -368,9 +368,13 @@ class YOLO(object):
         prev_time = timer()
         while True:
             return_value, frame = vid.read()
+            b, g, r = cv2.split(frame)
+            frame = cv2.merge([r, g, b])
             image = Image.fromarray(frame)
             image = self.detect_and_draw_image(image)
             result = np.asarray(image)
+            r, g, b = cv2.split(result)
+            result = cv2.merge([b, g, r])
             curr_time = timer()
             exec_time = curr_time - prev_time
             prev_time = curr_time


### PR DESCRIPTION
AaronJny 大大你好，opencv 读出来的颜色通道是按 BGR 的顺序，但 pillow 读取是按 RGB 的顺序，训练的时候 detect_image() 函数是使用 pillow 函数读取图片的，但用视频进行检测时是先用 opencv 读取的视频帧，所以这里需要加上将通道调换的代码，否则视频测试时输入 detect_and_draw_image() 的图片的通道顺序与训练时不一致。